### PR TITLE
Add GitHub Container Registry deployment with multi-platform builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,25 @@
-# Application Configuration
+# Environment Variable Hierarchy:
+# .env -> justfile -> docker compose -> app
+
+# ===== Core Application Settings =====
 SERVICE_NAME=python-tool
 PYTHON_ENV=development
 
-# Database Configuration
+# ===== Database Settings =====
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=app_db
 POSTGRES_HOST=127.0.0.1
 POSTGRES_PORT=5432
+
+# ===== Deployment Settings =====
+GIT_USER=mi-skam
+GIT_REGISTRY=ghcr.io
+# GIT_REPO - dynamically set in justfile
+# GIT_HASH - dynamically set in justfile
+
+# ===== Optional Settings =====
+# HOST=127.0.0.1  # Defaults in justfile
+# EXTERNAL_PORT=8098  # For production deployment
+# _UV_RUN_ARGS_TEST=""  # Extra args for test runner
+# _UV_RUN_ARGS_CLI=""  # Extra args for CLI runner

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -14,14 +14,14 @@ services:
       retries: 5
 
   cli-tool:
-    image: ${SERVICE_NAME}:latest
+    image: ${GIT_REGISTRY}/${GIT_USER}/${GIT_REPO}:${IMAGE_TAG:-latest}
     environment:
       - PYTHON_ENV=production
       - SERVICE_NAME=${SERVICE_NAME}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_HOST=postgres
+      - POSTGRES_HOST=postgres  # Use Docker service name
       - POSTGRES_PORT=5432
     depends_on:
       postgres:

--- a/src/python_tool/main.py
+++ b/src/python_tool/main.py
@@ -15,11 +15,11 @@ from .models import ExecutionLog, get_db_session
 def get_system_info():
     """Get system information."""
     config = dotenv_values(".env")
-
+    
     return {
         "python_version": sys.version,
         "environment": os.environ.get("PYTHON_ENV", "development"),
-        "service_name": config.get("SERVICE_NAME", "python-tool"),
+        "service_name": os.environ.get("SERVICE_NAME") or config.get("SERVICE_NAME", "python-tool"),
         "timestamp": datetime.now().isoformat(),
     }
 
@@ -44,7 +44,14 @@ def status_command(save_to_db: bool = False) -> dict:
     if save_to_db:
         try:
             config = dotenv_values(".env")
-            database_url = f"postgresql://{config['POSTGRES_USER']}:{config['POSTGRES_PASSWORD']}@{config['POSTGRES_HOST']}:{config['POSTGRES_PORT']}/{config['POSTGRES_DB']}"
+            # Prefer environment variables over .env file for containers
+            postgres_user = os.environ.get("POSTGRES_USER") or config.get("POSTGRES_USER")
+            postgres_password = os.environ.get("POSTGRES_PASSWORD") or config.get("POSTGRES_PASSWORD")
+            postgres_host = os.environ.get("POSTGRES_HOST") or config.get("POSTGRES_HOST")
+            postgres_port = os.environ.get("POSTGRES_PORT") or config.get("POSTGRES_PORT")
+            postgres_db = os.environ.get("POSTGRES_DB") or config.get("POSTGRES_DB")
+            
+            database_url = f"postgresql://{postgres_user}:{postgres_password}@{postgres_host}:{postgres_port}/{postgres_db}"
             session = get_db_session(database_url=database_url)
 
             # Store execution in database

--- a/src/python_tool/main.py
+++ b/src/python_tool/main.py
@@ -15,11 +15,12 @@ from .models import ExecutionLog, get_db_session
 def get_system_info():
     """Get system information."""
     config = dotenv_values(".env")
-    
+
     return {
         "python_version": sys.version,
         "environment": os.environ.get("PYTHON_ENV", "development"),
-        "service_name": os.environ.get("SERVICE_NAME") or config.get("SERVICE_NAME", "python-tool"),
+        "service_name": os.environ.get("SERVICE_NAME")
+        or config.get("SERVICE_NAME", "python-tool"),
         "timestamp": datetime.now().isoformat(),
     }
 
@@ -45,12 +46,20 @@ def status_command(save_to_db: bool = False) -> dict:
         try:
             config = dotenv_values(".env")
             # Prefer environment variables over .env file for containers
-            postgres_user = os.environ.get("POSTGRES_USER") or config.get("POSTGRES_USER")
-            postgres_password = os.environ.get("POSTGRES_PASSWORD") or config.get("POSTGRES_PASSWORD")
-            postgres_host = os.environ.get("POSTGRES_HOST") or config.get("POSTGRES_HOST")
-            postgres_port = os.environ.get("POSTGRES_PORT") or config.get("POSTGRES_PORT")
+            postgres_user = os.environ.get("POSTGRES_USER") or config.get(
+                "POSTGRES_USER"
+            )
+            postgres_password = os.environ.get("POSTGRES_PASSWORD") or config.get(
+                "POSTGRES_PASSWORD"
+            )
+            postgres_host = os.environ.get("POSTGRES_HOST") or config.get(
+                "POSTGRES_HOST"
+            )
+            postgres_port = os.environ.get("POSTGRES_PORT") or config.get(
+                "POSTGRES_PORT"
+            )
             postgres_db = os.environ.get("POSTGRES_DB") or config.get("POSTGRES_DB")
-            
+
             database_url = f"postgresql://{postgres_user}:{postgres_password}@{postgres_host}:{postgres_port}/{postgres_db}"
             session = get_db_session(database_url=database_url)
 


### PR DESCRIPTION
## Summary
- Added GitHub Container Registry (ghcr.io) deployment support with multi-platform builds
- Enhanced environment variable handling for container deployments
- Added deployment commands and production configuration

## Changes Made
- **Environment Configuration**: Added `GIT_USER`, `GIT_REGISTRY` variables to support GitHub Container Registry
- **Multi-platform Builds**: Docker builds now support both `linux/amd64` and `linux/arm64` architectures
- **Deployment Commands**: Added `build-container`, `push-container`, `test-deploy` to justfile
- **Production Configuration**: Updated `compose.prod.yml` to use GHCR image format with git hash tagging
- **Container Environment**: Fixed CLI tool to read environment variables properly in container context
- **Database Integration**: Ensured PostgreSQL connectivity works in production container environment

## New justfile Commands
- `just build-container` - Build multi-platform Docker images
- `just push-container` - Build and push images to GitHub Container Registry
- `just test-deploy` - Test deployment locally with production configuration

## Test Plan
- [x] CLI tool health check works in container
- [x] Echo command with JSON output works in container  
- [x] Status command with database integration works in container
- [x] Multi-platform Docker images build successfully
- [x] Images push to GitHub Container Registry (ghcr.io)
- [x] Production deployment with PostgreSQL database works
- [x] Environment variable hierarchy works (.env → justfile → docker compose → app)

🤖 Generated with [Claude Code](https://claude.ai/code)